### PR TITLE
Jakob/modularize transfer

### DIFF
--- a/src/Particles.h
+++ b/src/Particles.h
@@ -25,13 +25,6 @@ public:
     return _cell_particles;
   }
 
-  /// List of particles in a cell with (local) index \p cidx
-  const std::vector<int>& cell_particles(const int cidx) const
-  {
-    // TODO: assert validity of cidx
-    return _cell_particles[cidx];
-  }
-
   /// Add a particle to a cell
   /// @return New particle index
   int add_particle(const Eigen::VectorXd& x, int cell);

--- a/src/Particles.h
+++ b/src/Particles.h
@@ -25,6 +25,13 @@ public:
     return _cell_particles;
   }
 
+  /// List of particles in a cell with (local) index \p cidx
+  const std::vector<int>& cell_particles(const int cidx) const
+  {
+    // TODO: assert validity of cidx
+    return _cell_particles[cidx];
+  }
+
   /// Add a particle to a cell
   /// @return New particle index
   int add_particle(const Eigen::VectorXd& x, int cell);

--- a/src/setup.py
+++ b/src/setup.py
@@ -14,8 +14,9 @@ if sys.version_info < (3, 5):
 
 VERSION = "0.1"
 
+
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
+    def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 
@@ -23,14 +24,18 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            out = subprocess.check_output(["cmake", "--version"])
         except OSError:
-            raise RuntimeError("CMake must be installed to build the following extensions: "
-                               + ", ".join(e.name for e in self.extensions))
+            raise RuntimeError(
+                "CMake must be installed to build the following extensions: "
+                + ", ".join(e.name for e in self.extensions)
+            )
 
         if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
-            if cmake_version < '3.1.0':
+            cmake_version = LooseVersion(
+                re.search(r"version\s*([\d.]+)", out.decode()).group(1)
+            )
+            if cmake_version < "3.1.0":
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         for ext in self.extensions:
@@ -38,37 +43,48 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPython3_EXECUTABLE=' + sys.executable]
+        cmake_args = [
+            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
+            "-DPython3_EXECUTABLE=" + sys.executable,
+        ]
 
-        cfg = 'Debug' if self.debug else 'Release'
-        build_args = ['--config', cfg]
+        cfg = "Debug" if self.debug else "Release"
+        build_args = ["--config", cfg]
 
         if platform.system() == "Windows":
-            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            if sys.maxsize > 2**32:
-                cmake_args += ['-A', 'x64']
-            build_args += ['--', '/m']
+            cmake_args += [
+                "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir)
+            ]
+            if sys.maxsize > 2 ** 32:
+                cmake_args += ["-A", "x64"]
+            build_args += ["--", "/m"]
         else:
-            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            build_args += ['--', '-j3']
+            cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
+            build_args += ["--", "-j3"]
 
         env = os.environ.copy()
-        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
-                                                              self.distribution.get_version())
+        env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
+            env.get("CXXFLAGS", ""), self.distribution.get_version()
+        )
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(
+            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env
+        )
+        subprocess.check_call(
+            ["cmake", "--build", "."] + build_args, cwd=self.build_temp, env=env
+        )
 
 
-setup(name='leopart',
-      version=VERSION,
-      author='LEoPart-X Project',
-      description='LEoPart Python interface',
-      long_description='',
-      packages=["leopart"],
-      package_data={'dolfinx.wrappers': ['*.h']},
-      ext_modules=[CMakeExtension('pyleopart')],
-      cmdclass=dict(build_ext=CMakeBuild),
-      zip_safe=False)
+setup(
+    name="leopart",
+    version=VERSION,
+    author="LEoPart-X Project",
+    description="LEoPart Python interface",
+    long_description="",
+    packages=["leopart"],
+    package_data={"dolfinx.wrappers": ["*.h"]},
+    ext_modules=[CMakeExtension("pyleopart")],
+    cmdclass=dict(build_ext=CMakeBuild),
+    zip_safe=False,
+)

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -50,12 +50,8 @@ transfer::get_particle_contributions(
   const int reference_value_size = element->reference_value_size() / block_size;
   const int value_size = element->value_size() / block_size;
   const int space_dimension = element->space_dimension() / block_size;
-  // std::cout << "Block size here is " << block_size << std::endl;
-  std::cout << "Num dofs g" << num_dofs_g << std::endl;
-  std::cout << "Value size here is " << value_size << std::endl;
-  std::cout << "Space dimension here is " << space_dimension << std::endl;
-  // Prepare geometry data structures
 
+  // Prepare geometry data structures
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       coordinate_dofs(num_dofs_g, gdim);
 
@@ -108,8 +104,5 @@ transfer::get_particle_contributions(
               basis_data.row(p).data());
     p += np;
   }
-  std::cout << "Basis data row " << 1 << std::endl;
-  std::cout << basis_data.row(0) << std::endl;
-  std::cout << basis_data.row(1) << std::endl;
   return basis_data;
 }

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -46,10 +46,14 @@ transfer::get_particle_contributions(
   std::shared_ptr<const dolfinx::fem::FiniteElement> element
       = function_space.element();
   assert(element);
-  const int reference_value_size = element->reference_value_size();
-  const int value_size = element->value_size();
-  const int space_dimension = element->space_dimension();
-
+  const int block_size = element->block_size();
+  const int reference_value_size = element->reference_value_size() / block_size;
+  const int value_size = element->value_size() / block_size;
+  const int space_dimension = element->space_dimension() / block_size;
+  // std::cout << "Block size here is " << block_size << std::endl;
+  std::cout << "Num dofs g" << num_dofs_g << std::endl;
+  std::cout << "Value size here is " << value_size << std::endl;
+  std::cout << "Space dimension here is " << space_dimension << std::endl;
   // Prepare geometry data structures
 
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
@@ -104,6 +108,8 @@ transfer::get_particle_contributions(
               basis_data.row(p).data());
     p += np;
   }
-
+  std::cout << "Basis data row " << 1 << std::endl;
+  std::cout << basis_data.row(0) << std::endl;
+  std::cout << basis_data.row(1) << std::endl;
   return basis_data;
 }

--- a/src/transfer.h
+++ b/src/transfer.h
@@ -148,7 +148,6 @@ void transfer_to_particles(
   }
 }
 //----------------------------------------------------------------------------
-
 void eval_particle_cell_contributions(
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& q,
     Eigen::VectorXd& l, int* row_idx, const Particles& pax, const Field& field,

--- a/src/transfer.h
+++ b/src/transfer.h
@@ -37,7 +37,9 @@ void transfer_to_particles(
     const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
         basis_values);
 
-/// Evaluate the basis functions at particle positions in a prescribed cell
+/// Evaluate the basis functions at particle positions in a prescribed cell.
+/// Writes results to an Eigen::Matrix \f$q\f$ and Eigen::Vector \f$f\f$ to
+/// compose the l2 problem \f$q q^T = q f\f$.
 void eval_particle_cell_contributions(
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& q,
     Eigen::VectorXd& l, int* row_idx, const Particles& pax, const Field& field,
@@ -80,7 +82,7 @@ void transfer_to_function(
     eval_particle_cell_contributions(q, l, &row_idx, pax, field, c, value_size,
                                      space_dimension, basis_values);
 
-    // Do l2 projection
+    // Solve projection
     Eigen::VectorXd u_i = (q * q.transpose()).ldlt().solve(q * l);
     auto dofs = dm->cell_dofs(c);
 

--- a/src/transfer.h
+++ b/src/transfer.h
@@ -43,8 +43,8 @@ void transfer_to_particles(
 void eval_particle_cell_contributions(
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& q,
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& l,
-    int* row_idx, const Particles& pax, const Field& field, const int cidx,
-    const int value_size, const int space_dimension, const int block_size,
+    int* row_idx, const Particles& pax, const Field& field, int cidx,
+    int space_dimension, int block_size,
     const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
         basis_values);
 //----------------------------------------------------------------------------
@@ -80,26 +80,19 @@ void transfer_to_function(
   for (int c = 0; c < ncells; ++c)
   {
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> q;
-    // Eigen::VectorXd l;
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> l;
-    eval_particle_cell_contributions(q, l, &row_idx, pax, field, c, value_size,
+    eval_particle_cell_contributions(q, l, &row_idx, pax, field, c,
                                      space_dimension, block_size, basis_values);
 
-    // Solve projection
-    // Eigen::VectorXd u_i = (q * q.transpose()).ldlt().solve(q * l);
-    // Eigen::VectorXd u_i = (q.transpose() * q).inverse() * (q.transpose() *
-    // l);
+    // Solve projection where
+    // - q has shape [ndofs/block_size, np]
+    // - l has shape [np, block_size]
+    // Maybe expand q and expand l to make sure we have a proper least square
+    // problem
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> u_tmp
-        = ((q.transpose() * q).inverse() * (q.transpose() * l));
-    // Eigen::VectorXd u_i(Eigen::Map<Eigen::VectorXd>(u_tmp.data(),
-    // u_tmp.cols()*u_tmp.rows()));
+        = ((q * q.transpose()).inverse() * (q * l));
     Eigen::Map<Eigen::VectorXd> u_i(u_tmp.data(), space_dimension * block_size);
-    if (c == 0)
-    {
-      std::cout << "This was q in cell 0 \n" << q << std::endl;
-      std::cout << "This was l in cell 0 \n" << l << std::endl;
-      std::cout << "Solution cell 0 is \n" << u_i << std::endl;
-    }
+
     auto dofs = dm->cell_dofs(c);
 
     assert(dofs.size() == space_dimension);
@@ -152,7 +145,7 @@ void transfer_to_particles(
     {
       vals[k] = f_array[dofs[k]];
     }
-    // Cast
+    // Cast as matrix of size [block_size, space_dimension/block_size]
     Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
                                    Eigen::ColMajor>>
         vals_mat(vals.data(), block_size, space_dimension);
@@ -161,23 +154,10 @@ void transfer_to_particles(
     {
       Eigen::Map<Eigen::VectorXd> ptr = field.data(pidx);
       ptr.setZero();
-      // Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-      //                                Eigen::ColMajor>>
-      //     q(basis_values.row(idx++).data(), value_size, space_dimension);
-      Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                                     Eigen::ColMajor>>
-          q(basis_values.row(idx++).data(), space_dimension, value_size);
-      // Eigen::Map<const Eigen::VectorXd>
-      //     q(basis_values.row(idx++).data());
-      // ptr = q * vals;
+      Eigen::Map<const Eigen::VectorXd> q(basis_values.row(idx++).data(),
+                                          space_dimension);
+
       ptr = vals_mat * q;
-      if (c == 0 && pidx == 0)
-      {
-        std::cout << "IDX IS" << idx << std::endl;
-        // std::cout << "Casted to \n"<< q << std::endl;
-        std::cout << "Vals \n" << vals << std::endl;
-        std::cout << "Ptr result \n" << ptr << std::endl;
-      }
     }
   }
 }
@@ -185,43 +165,23 @@ void transfer_to_particles(
 void eval_particle_cell_contributions(
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& q,
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& l,
-    int* row_idx, const Particles& pax, const Field& field, const int cidx,
-    const int value_size, const int space_dimension, int block_size,
+    int* row_idx, const Particles& pax, const Field& field, int cidx,
+    int space_dimension, int block_size,
     const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
         basis_values)
 {
   // Get particles in cell cidx
   const std::vector<int>& cell_particles = pax.cell_particles(cidx);
   int np = cell_particles.size();
-  // q.resize(space_dimension, np * value_size);
-  // l.resize(np * value_size);
-  q.resize(np, space_dimension);
-  // l.resize(np * value_size);
+  q.resize(space_dimension, np);
   l.resize(np, block_size);
-  if (cidx == 0)
-  {
-    std::cout << "Num particles " << np << std::endl;
-  }
   for (int p = 0; p < np; ++p)
   {
     int pidx = cell_particles[p];
     Eigen::Map<const Eigen::VectorXd> basis(
         basis_values.row((*row_idx)++).data(), space_dimension);
-    // Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-    //                                Eigen::RowMajor>>
-    //     basis(basis_values.row((*row_idx)++).data(), 1, space_dimension);
-
-    // q.block(p, 0, 1, space_dimension) = basis;
-    q.row(p) = basis;
-    // q.block(0, p * value_size, space_dimension, value_size) = basis;
-    // l.segment(p * value_size, value_size) = field.data(pidx);
-    // l.block(p, 0, 1, block_size) = Eigen::Map<field.data(pidx);
+    q.col(p) = basis;
     l.row(p) = field.data(pidx);
-    if (cidx == 0 && (p == 0 || p == 1))
-    {
-      std::cout << "Particle value " << p << "\n"
-                << field.data(pidx) << std::endl;
-    }
   }
 }
 } // namespace transfer

--- a/src/transfer.h
+++ b/src/transfer.h
@@ -140,7 +140,7 @@ void transfer_to_particles(
       Eigen::Map<Eigen::VectorXd> ptr = field.data(pidx);
       ptr.setZero();
       Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                                     Eigen::ColMajor>>
+                                     Eigen::RowMajor>>
           q(basis_values.row(idx++).data(), value_size, space_dimension);
 
       ptr = q * vals;

--- a/src/transfer.h
+++ b/src/transfer.h
@@ -82,17 +82,15 @@ void transfer_to_function(
   for (int c = 0; c < ncells; ++c)
   {
     std::vector<int> cell_particles = pax.cell_particles()[c];
-    std::pair<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>,
-              Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>
-        ql = eval_particle_cell_contributions(cell_particles, field,
-                                              basis_values, row_offset,
-                                              space_dimension, block_size);
+    auto [q, l] = eval_particle_cell_contributions(cell_particles, field,
+                                                   basis_values, row_offset,
+                                                   space_dimension, block_size);
 
     // Solve projection where
-    // - ql.first --> q has shape [ndofs/block_size, np]
-    // - ql.second --> l has shape [np, block_size]
+    // - q has shape [ndofs/block_size, np]
+    // - l has shape [np, block_size]
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> u_tmp
-        = (ql.first * ql.first.transpose()).ldlt().solve(ql.first * ql.second);
+        = (q * q.transpose()).ldlt().solve(q * l);
     Eigen::Map<Eigen::VectorXd> u_i(u_tmp.data(), space_dimension * block_size);
 
     auto dofs = dm->cell_dofs(c);

--- a/src/transfer.h
+++ b/src/transfer.h
@@ -90,7 +90,7 @@ void transfer_to_function(
     // Maybe expand q and expand l to make sure we have a proper least square
     // problem
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> u_tmp
-        = ((q * q.transpose()).inverse() * (q * l));
+        = (q * q.transpose()).ldlt().solve(q * l);
     Eigen::Map<Eigen::VectorXd> u_i(u_tmp.data(), space_dimension * block_size);
 
     auto dofs = dm->cell_dofs(c);

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -38,7 +38,8 @@ PYBIND11_MODULE(pyleopart, m)
       .def("field",
            py::overload_cast<std::string>(&Particles::Particles::field),
            py::return_value_policy::reference_internal)
-      .def("cell_particles", &Particles::Particles::cell_particles);
+      .def("cell_particles", py::overload_cast<>(&Particles::Particles::cell_particles, py::const_))
+      .def("cell_particles", py::overload_cast<const int>(&Particles::Particles::cell_particles, py::const_));
 
   // Generation functions
   m.def("random_tet", &generation::random_reference_tetrahedron);

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -38,8 +38,9 @@ PYBIND11_MODULE(pyleopart, m)
       .def("field",
            py::overload_cast<std::string>(&Particles::Particles::field),
            py::return_value_policy::reference_internal)
-      .def("cell_particles", py::overload_cast<>(&Particles::Particles::cell_particles, py::const_))
-      .def("cell_particles", py::overload_cast<const int>(&Particles::Particles::cell_particles, py::const_));
+      .def("cell_particles",
+           py::overload_cast<>(&Particles::Particles::cell_particles,
+                               py::const_));
 
   // Generation functions
   m.def("random_tet", &generation::random_reference_tetrahedron);

--- a/test/test_interpolate_project.py
+++ b/test/test_interpolate_project.py
@@ -11,7 +11,12 @@ def test_interpolate_project():
     x, c = pyleopart.mesh_fill(mesh, ncells*npart)
     p = pyleopart.Particles(x, c)
 
+    Qt = dolfinx.function.FunctionSpace(mesh, ("DG", 2))
+    print(f"Space dimension is {Qt.element.space_dimension()}")
     Q = dolfinx.function.VectorFunctionSpace(mesh, ("DG", 2))
+    print(dir(Q.element))
+    print(f"Space dimension is {Q.element.space_dimension()}")
+    print(f"Value size is {Q.element.value_rank}")
     pbasis = pyleopart.get_particle_contributions(p, Q._cpp_object)
 
     def sq_val(x):

--- a/test/test_interpolate_project.py
+++ b/test/test_interpolate_project.py
@@ -4,36 +4,26 @@ import numpy as np
 import pyleopart
 import pytest
 
-# Test back-and-forth projection on 2D mesh
-@pytest.mark.parametrize("is_vec, k", [(True, 2), (True, 3), (False, 2), (False, 3)])
-def test_interpolate_project_dg(is_vec, k):
+# Test back-and-forth projection on 2D mesh: scalar case
+@pytest.mark.parametrize("k", [2, 3])
+def test_interpolate_project_dg_scalar(k):
     npart = 20
     mesh = dolfinx.UnitSquareMesh(MPI.COMM_WORLD, 5, 5)
     ncells = mesh.topology.index_map(2).size_local
     x, c = pyleopart.mesh_fill(mesh, ncells * npart)
     p = pyleopart.Particles(x, c)
 
-    Q = (
-        dolfinx.function.VectorFunctionSpace(mesh, ("DG", k))
-        if is_vec
-        else dolfinx.function.FunctionSpace(mesh, ("DG", k))
-    )
+    Q = dolfinx.function.FunctionSpace(mesh, ("DG", k))
+
     pbasis = pyleopart.get_particle_contributions(p, Q._cpp_object)
 
-    if is_vec:
-
-        def sq_val(x):
-            return [x[0] ** k, x[1] ** k]
-
-    else:
-
-        def sq_val(x):
-            return x[0] ** k
+    def sq_val(x):
+        return x[0] ** k
 
     u = dolfinx.function.Function(Q)
     u.interpolate(sq_val)
 
-    p.add_field("v", [2]) if is_vec else p.add_field("v", [1])
+    p.add_field("v", [1])
     v = p.field("v")
 
     # Transfer from Function "u" to field "v"
@@ -42,14 +32,50 @@ def test_interpolate_project_dg(is_vec, k):
     # Transfer from field "v" back to Function "u"
     pyleopart.transfer_to_function(u._cpp_object, p, v, pbasis)
 
-    p.add_field("w", [2]) if is_vec else p.add_field("w", [1])
+    p.add_field("w", [1])
     w = p.field("w")
     # Transfer from Function "u" to field "w"
     pyleopart.transfer_to_particles(p, w, u._cpp_object, pbasis)
 
     # Compare fields "w" and "x"(squared)
     for pidx in range(len(x)):
-        expected = (
-            p.field("x").data(pidx) ** k if is_vec else p.field("x").data(pidx)[0] ** k
-        )
+        expected = p.field("x").data(pidx)[0] ** k
+        assert np.isclose(p.field("w").data(pidx), expected).all()
+
+
+# Test back-and-forth projection on 2D mesh: vector valued case
+@pytest.mark.parametrize("k", [2, 3])
+def test_interpolate_project_dg_vector(k):
+    npart = 20
+    mesh = dolfinx.UnitSquareMesh(MPI.COMM_WORLD, 5, 5)
+    ncells = mesh.topology.index_map(2).size_local
+    x, c = pyleopart.mesh_fill(mesh, ncells * npart)
+    p = pyleopart.Particles(x, c)
+
+    Q = dolfinx.function.VectorFunctionSpace(mesh, ("DG", k))
+    pbasis = pyleopart.get_particle_contributions(p, Q._cpp_object)
+
+    def sq_val(x):
+        return [x[0] ** k, x[1] ** k]
+
+    u = dolfinx.function.Function(Q)
+    u.interpolate(sq_val)
+
+    p.add_field("v", [2])
+    v = p.field("v")
+
+    # Transfer from Function "u" to field "v"
+    pyleopart.transfer_to_particles(p, v, u._cpp_object, pbasis)
+
+    # Transfer from field "v" back to Function "u"
+    pyleopart.transfer_to_function(u._cpp_object, p, v, pbasis)
+
+    p.add_field("w", [2])
+    w = p.field("w")
+    # Transfer from Function "u" to field "w"
+    pyleopart.transfer_to_particles(p, w, u._cpp_object, pbasis)
+
+    # Compare fields "w" and "x"(squared)
+    for pidx in range(len(x)):
+        expected = p.field("x").data(pidx) ** k
         assert np.isclose(p.field("w").data(pidx), expected).all()

--- a/test/test_interpolate_project.py
+++ b/test/test_interpolate_project.py
@@ -2,47 +2,54 @@ import dolfinx
 from mpi4py import MPI
 import numpy as np
 import pyleopart
+import pytest
 
-
-def test_interpolate_project():
+# Test back-and-forth projection on 2D mesh
+@pytest.mark.parametrize("is_vec, k", [(True, 2), (True, 3), (False, 2), (False, 3)])
+def test_interpolate_project_dg(is_vec, k):
     npart = 20
     mesh = dolfinx.UnitSquareMesh(MPI.COMM_WORLD, 5, 5)
     ncells = mesh.topology.index_map(2).size_local
-    x, c = pyleopart.mesh_fill(mesh, ncells*npart)
+    x, c = pyleopart.mesh_fill(mesh, ncells * npart)
     p = pyleopart.Particles(x, c)
 
-    Qt = dolfinx.function.FunctionSpace(mesh, ("DG", 2))
-    print(f"Space dimension is {Qt.element.space_dimension()}")
-    Q = dolfinx.function.VectorFunctionSpace(mesh, ("DG", 2))
-    print(dir(Q.element))
-    print(f"Space dimension is {Q.element.space_dimension()}")
-    print(f"Value size is {Q.element.value_rank}")
+    Q = (
+        dolfinx.function.VectorFunctionSpace(mesh, ("DG", k))
+        if is_vec
+        else dolfinx.function.FunctionSpace(mesh, ("DG", k))
+    )
     pbasis = pyleopart.get_particle_contributions(p, Q._cpp_object)
 
-    def sq_val(x):
-        return [x[0]**2, x[1]**2]
+    if is_vec:
+
+        def sq_val(x):
+            return [x[0] ** k, x[1] ** k]
+
+    else:
+
+        def sq_val(x):
+            return x[0] ** k
 
     u = dolfinx.function.Function(Q)
     u.interpolate(sq_val)
 
-    p.add_field("v", [2])
+    p.add_field("v", [2]) if is_vec else p.add_field("v", [1])
     v = p.field("v")
 
     # Transfer from Function "u" to field "v"
     pyleopart.transfer_to_particles(p, v, u._cpp_object, pbasis)
 
-    # Compare fields "w" and "x"(squared)
-    for pidx in range(len(x)):
-        assert np.isclose(p.field("v").data(pidx), p.field("x").data(pidx)**2).all()
-
     # Transfer from field "v" back to Function "u"
     pyleopart.transfer_to_function(u._cpp_object, p, v, pbasis)
 
-    p.add_field("w", [2])
+    p.add_field("w", [2]) if is_vec else p.add_field("w", [1])
     w = p.field("w")
     # Transfer from Function "u" to field "w"
     pyleopart.transfer_to_particles(p, w, u._cpp_object, pbasis)
 
     # Compare fields "w" and "x"(squared)
     for pidx in range(len(x)):
-        assert np.isclose(p.field("w").data(pidx), p.field("x").data(pidx)**2).all()
+        expected = (
+            p.field("x").data(pidx) ** k if is_vec else p.field("x").data(pidx)[0] ** k
+        )
+        assert np.isclose(p.field("w").data(pidx), expected).all()

--- a/test/test_interpolate_project.py
+++ b/test/test_interpolate_project.py
@@ -26,6 +26,10 @@ def test_interpolate_project():
     # Transfer from Function "u" to field "v"
     pyleopart.transfer_to_particles(p, v, u._cpp_object, pbasis)
 
+    # Compare fields "w" and "x"(squared)
+    for pidx in range(len(x)):
+        assert np.isclose(p.field("v").data(pidx), p.field("x").data(pidx)**2).all()
+
     # Transfer from field "v" back to Function "u"
     pyleopart.transfer_to_function(u._cpp_object, p, v, pbasis)
 


### PR DESCRIPTION
Make the transfer functions a bit more modular, so that they can be reused for different projections (e.g. DG, bound constraint DG, CG, PDE constrained, ...) 

Furthermore, merge request accounts for the changes due to https://github.com/FEniCS/dolfinx/pull/1088 (ordering of dof entries)